### PR TITLE
fix(infra): update environment file paths in production Compose and J…

### DIFF
--- a/infra/production.compose.yml
+++ b/infra/production.compose.yml
@@ -15,7 +15,7 @@ services:
         - marlonangeli/iot:logi-web-${COMMIT_HASH}
         - marlonangeli/iot:logi-web-latest
     env_file:
-      - ../web/.env
+      - .env
     environment:
       NODE_ENV: production
       NEXT_PUBLIC_AUTH_API_URL: ${AUTH_API_URL}

--- a/web/Jenkinsfile
+++ b/web/Jenkinsfile
@@ -27,11 +27,11 @@ pipeline {
       steps {
         script {
           withCredentials([file(credentialsId: 'web_dotenv', variable: 'web_dotenv')]) {
-            sh "cp ${web_dotenv} web/.env"
+            sh "cp ${web_dotenv} infra/.env"
             
             sh """
               export COMMIT_HASH=${COMMIT_HASH}
-              docker compose --file infra/production.compose.yml --env-file web/.env build logi-web
+              docker compose --file infra/production.compose.yml --env-file infra/.env build logi-web
             """
           }
           
@@ -50,7 +50,7 @@ pipeline {
     stage('Deploy') {
       steps {
         script {
-          sh "docker compose --file infra/production.compose.yml --env-file web/.env up -d logi-web"
+          sh "docker compose --file infra/production.compose.yml --env-file infra/.env up -d logi-web"
         }
       }
     }


### PR DESCRIPTION
This pull request includes changes to the environment file configuration in the `infra/production.compose.yml` and `web/Jenkinsfile` files. The updates ensure that the `.env` file in the `infra` directory is used consistently across the build and deployment processes.

Environment file configuration updates:

* [`infra/production.compose.yml`](diffhunk://#diff-4388f5a1d6808d5390ce39265fdc7aa26c6905b9ed071b8957b187c83e8905acL18-R18): Changed the `env_file` path from `../web/.env` to `.env` to use the `.env` file in the `infra` directory.
* [`web/Jenkinsfile`](diffhunk://#diff-80c0ecea42493cfc0641d362e4cd4cbae84e03c6213f159ac86e8e71446367feL30-R34): Updated the `cp` command to copy the `web_dotenv` file to the `infra` directory instead of the `web` directory.
* [`web/Jenkinsfile`](diffhunk://#diff-80c0ecea42493cfc0641d362e4cd4cbae84e03c6213f159ac86e8e71446367feL30-R34): Modified the `docker compose` commands to use the `.env` file in the `infra` directory for both the build and deploy stages. [[1]](diffhunk://#diff-80c0ecea42493cfc0641d362e4cd4cbae84e03c6213f159ac86e8e71446367feL30-R34) [[2]](diffhunk://#diff-80c0ecea42493cfc0641d362e4cd4cbae84e03c6213f159ac86e8e71446367feL53-R53)…enkinsfile