### PR TITLE
fix(infra): add PORT environment variable and log validation in config

### DIFF
--- a/auth/pkg/config/config.go
+++ b/auth/pkg/config/config.go
@@ -54,5 +54,7 @@ func (c Config) Validate() error {
 	if c.JWTSecret == "" {
 		return fmt.Errorf("JWT_SECRET must be set")
 	}
+
+    log.Println("Config is valid")
 	return nil
 }

--- a/infra/production.compose.yml
+++ b/infra/production.compose.yml
@@ -103,6 +103,7 @@ services:
       - .env
     environment:
       GIN_MODE: release
+      PORT: ${AUTH_PORT}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.auth.rule=Host(`iot.marlonangeli.com.br`) && PathPrefix(`/auth`)"
@@ -112,6 +113,8 @@ services:
       - "traefik.http.routers.auth.tls=true"
       - "traefik.http.routers.service=auth"
       - "traefik.http.services.auth.loadbalancer.server.port=5000"
+    networks:
+      - traefik-network
 
 networks:
   traefik-network:


### PR DESCRIPTION
This pull request includes changes to the `auth/pkg/config/config.go` and `infra/production.compose.yml` files. The most important changes are the addition of a log statement in the configuration validation function and updates to the Docker Compose file to include a new environment variable and network configuration.

Changes to configuration validation:

* [`auth/pkg/config/config.go`](diffhunk://#diff-01948b7aaee715cfd202612870c0b150d81d4d838b623799dc8bc212da160882R57-R58): Added a log statement to indicate that the configuration is valid in the `Validate` function.

Updates to Docker Compose:

* [`infra/production.compose.yml`](diffhunk://#diff-4388f5a1d6808d5390ce39265fdc7aa26c6905b9ed071b8957b187c83e8905acR106): Added the `PORT` environment variable to the `services` section.
* [`infra/production.compose.yml`](diffhunk://#diff-4388f5a1d6808d5390ce39265fdc7aa26c6905b9ed071b8957b187c83e8905acR116-R117): Added the `traefik-network` to the `services` section and defined the network at the bottom of the file.